### PR TITLE
Feature/enhance makefile

### DIFF
--- a/aichallenge/Makefile
+++ b/aichallenge/Makefile
@@ -2,40 +2,35 @@ sim:
 	@sudo ip link set multicast on lo
 	@sudo sysctl -w net.core.rmem_max=2147483647 >/dev/null
 	@echo "Start AWSIM"
-	@/aichallenge/simulator/AWSIM/AWSIM.x86_64 > /dev/null
-
-gpu-sim:
-	@sudo ip link set multicast on lo
-	@sudo sysctl -w net.core.rmem_max=2147483647 >/dev/null
-	@echo "Start AWSIM with GPU"
-	@/aichallenge/simulator/AWSIM_GPU/AWSIM.x86_64 > /dev/null
+	@${AWSIM_PATH}/AWSIM.x86_64 --timeout 86400.0 &
 
 rviz:
 	@echo "Start RVIZ"
-	ros2 run rviz2 rviz2 -d /aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/autoware.rviz.custom
+	ros2 run rviz2 rviz2 -d /aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/autoware.rviz.custom &
+	@ros2 run aichallenge_system_launch object_marker.py &
 
 aw:
 	@echo "Start Auwoware"
-	ros2 run aichallenge_system_launch object_marker.py &
-	ros2 run aichallenge_system_launch control_mode_adapter.py &
-	ros2 launch aichallenge_submit_launch aichallenge_submit.launch.xml
+	@ros2 run aichallenge_system_launch control_mode_adapter.py &
+	@ros2 run goal_pose_setter goal_pose_setter_node --ros-args --params-file $(shell ros2 pkg prefix --share goal_pose_setter)/config/default_goal_pose.param.yaml &
+	@ros2 launch aichallenge_submit_launch reference.launch.xml vehicle_model:=racing_kart sensor_model:=racing_kart_sensor_kit map_path:=$(shell ros2 pkg prefix --share aichallenge_submit_launch)/map &
+
+mpc: start
+	@echo "Start MPC"
+	@ros2 launch multi_purpose_mpc_ros mpc_controller.launch.py &
 
 start:
 	@echo "Start cotnrol"
-	ros2 topic pub --once /control/control_mode_request_topic std_msgs/msg/Bool '{data: true}' >/dev/null
+	ros2 topic pub -t 10 /control/control_mode_request_topic std_msgs/msg/Bool '{data: true}' >/dev/null &
 
-dev:
-	@sudo ip link set multicast on lo
-	@sudo sysctl -w net.core.rmem_max=2147483647 >/dev/null
-	@echo "Start AWSIM"
-	@/aichallenge/simulator/AWSIM/AWSIM.x86_64 > /dev/null &
+reset:
+	@echo "Reset simulation"
+	@ros2 topic pub --once /aichallenge/awsim/reset std_msgs/msg/Empty {} >/dev/null &
 
-	ros2 run rviz2 rviz2 -d /aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/autoware.rviz.custom &
+kill:
+	@echo "Kill all"
+	@bash -i -c "rkill"
 
-	ros2 run aichallenge_system_launch object_marker.py &
-	ros2 run aichallenge_system_launch control_mode_adapter.py &
-	ros2 launch aichallenge_submit_launch aichallenge_submit.launch.xml &
+setup: sim rviz aw
 
-	@sleep 5
-	@echo "Start cotnrol"
-	ros2 topic pub --once /control/control_mode_request_topic std_msgs/msg/Bool '{data: true}' >/dev/null &
+all: sim rviz aw mpc

--- a/aichallenge/Makefile
+++ b/aichallenge/Makefile
@@ -6,7 +6,7 @@ sim:
 
 rviz:
 	@echo "Start RVIZ"
-	ros2 run rviz2 rviz2 -d /aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/autoware.rviz.custom &
+	@ros2 run rviz2 rviz2 -d /aichallenge/workspace/src/aichallenge_system/aichallenge_system_launch/config/autoware.rviz.custom --ros-args -r rviz:/initialpose:=/localization/initial_pose3d &
 	@ros2 run aichallenge_system_launch object_marker.py &
 
 aw:
@@ -26,6 +26,7 @@ start:
 reset:
 	@echo "Reset simulation"
 	@ros2 topic pub --once /aichallenge/awsim/reset std_msgs/msg/Empty {} >/dev/null &
+	@ros2 run multi_purpose_mpc_ros publish_initialpose
 
 kill:
 	@echo "Kill all"

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/aichallenge_submit.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/aichallenge_submit.launch.xml
@@ -7,6 +7,9 @@
     <arg name="map_path" value="$(find-pkg-share aichallenge_submit_launch)/map"/>
   </include>
 
+  <!-- MPC -->
+  <include file="$(find-pkg-share multi_purpose_mpc_ros)/launch/mpc_controller.launch.py" />
+
   <!-- place a goal pose anywhere you like-->
   <node pkg="goal_pose_setter" exec="goal_pose_setter_node" name="goal_pose_setter" output="screen">
     <param from="$(find-pkg-share goal_pose_setter)/config/default_goal_pose.param.yaml" />

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
@@ -16,8 +16,6 @@
   <arg name="launch_vehicle_interface" default="false"/>
   <!-- System -->
   <arg name="system_run_mode" default="online" description="run mode in system"/>
-  <!-- MPC -->
-  <arg name="mpc_config_path" default="$(find-pkg-share multi_purpose_mpc_ros)/config/config.yaml" description="MPC config file path"/>
 
   <!-- Global parameters -->
   <group scoped="false">

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
@@ -217,11 +217,6 @@
     <remap from="output/control_cmd" to="/control/command/control_cmd"/>
   </node> -->
 
-  <node pkg="multi_purpose_mpc_ros" exec="run_mpc_controller.bash" name="mpc_controller" output="screen"
-    args="--config_path $(var mpc_config_path)">
-    <param name="use_sim_time" value="true"/>
-  </node>
-
   <!-- Map -->
   <group>
     <push-ros-namespace namespace="map"/>


### PR DESCRIPTION
開発効率化のため Makefile 周りを更新しました。

- `make sim` コマンドを CPU, GPU で共通化
  - ※https://github.com/Roborovsky-Racers/aic_docker/commit/ce3c499935e4fd96908d7c6c98d311b0dd805135 の変更を取り込む必要があります
- MPCを起動する `make mpc` コマンドを追加
- AWSIM の車両位置をリセットする `make reset` コマンドを追加
  - ※最新の AWSIM をダウンロードする必要があります
  - MPC側の main も pull してください
- AWSIM, rviz, Autoware 関連をまとめて起動する `make setup` を追加（修正）
- AWSIM, rviz, Autoware 関連, MPC をまとめて実行する `make all` コマンドを追加
- AWSIM、ROS2関連プロセスを全て kill する `make kill` を追加 (rkill と同じ）

MPC 等の開発において想定する実行手順は以下のようになるかなと思います。
  1. `make setup` を実行し、基本的な実行環境を起動する
  2.  `make mpc` を実行して自律制御を開始する
  3. 適当なタイミングで MPC を終了する
  4. `make reset` でAWSIMの車両位置をスタート地点に戻す
  5. 2 に戻る
  END: make kill で全てのプロセスを終了する
