### PR TITLE
mute dummy perception

### DIFF
--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/reference.launch.xml
@@ -96,9 +96,9 @@
   </group>
 
   <!-- Dummy Perception -->
-  <node pkg="dummy_perception_publisher" exec="empty_objects_publisher" name="empty_objects_publisher" output="screen">
+  <!-- <node pkg="dummy_perception_publisher" exec="empty_objects_publisher" name="empty_objects_publisher" output="screen">
     <remap from="~/output/objects" to="/perception/object_recognition/objects"/>
-  </node>
+  </node> -->
 
   <!-- Planning -->
   <group>


### PR DESCRIPTION
Dummy Perception を無効化しました。
これにより `planning/scenario_planning/trajectory` トピックが pub されなくなります。
このトピックは現在使用していないので、可視化されるとややこしいので無効化したいです。

---
実機動作までには本トピックを再度有効化し、 mpc_controller 側で本トピックから取得するように切り替える（ピットへのアクセス経路の件含め）方が良いとは思っています。