### PR TITLE
sim動作時に velocity_heat_odom_visualizer が使用する kinematic_state の rateを制限するように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 result-details.json
 rosbag2*
 .vscode/
+.cache/

--- a/aichallenge/Makefile
+++ b/aichallenge/Makefile
@@ -14,6 +14,7 @@ rviz:
 
 aw:
 	@echo "Start Autoware in SIM"
+	@ros2 launch aichallenge_submit_launch additional.launch.xml &
 	@ros2 launch aichallenge_system_launch aichallenge_system.launch.xml simulation:=true use_sim_time:=true run_rviz:=true rviz_config:=$(RVIZ_CONFIG) >autoware.log 2>&1 &
 
 vehicle:

--- a/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/additional.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_submit/aichallenge_submit_launch/launch/additional.launch.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+
+  <arg name="kinematic_state_rate" default="1.0"/>
+
+  <group>
+    <node pkg="multi_purpose_mpc_ros" exec="velocity_heat_odom_visualizer" name="velocity_heat_odom_visualizer" output="screen">
+      <remap from="/localization/kinematic_state" to="/localization/kinematic_state_throttle"/>
+    </node>
+
+    <node pkg="topic_tools" exec="throttle" name="kinemtic_state_throttle" output="screen" args="messages /localization/kinematic_state $(var kinematic_state_rate) /localization/kinematic_state_throttle"/>
+  </group>
+
+</launch>


### PR DESCRIPTION
通常sim動作だと kinematic_state の rate が高くvelocity_heat_odom_visualizer の描画が密すぎるため、描画に使用する kinematic_state を throttleを介して rate制限してpublishするように変更しました。
`make setup` 時に該当launchを一緒に軌道するようにしてあります。