### PR TITLE
Feature/enhance act cmd converter

### DIFF
--- a/aichallenge/plotjuggler/accel_steer.xml
+++ b/aichallenge/plotjuggler/accel_steer.xml
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<root>
+ <tabbed_widget parent="main_window" name="Main Window">
+  <Tab containers="1" tab_name="tab1">
+   <Container>
+    <DockSplitter count="2" orientation="-" sizes="0.5;0.5">
+     <DockArea name="...">
+      <plot style="Lines" flip_y="false" mode="TimeSeries" flip_x="false">
+       <range right="9.678637" bottom="-1.487106" top="0.482146" left="0.000000"/>
+       <limitY/>
+       <curve color="#d62728" name="/localization/acceleration/accel/accel/linear/x"/>
+       <curve color="#1ac938" name="/control/command/control_cmd/longitudinal/acceleration"/>
+       <curve color="#f14cc1" name="/awsim/control_cmd/longitudinal/acceleration"/>
+       <curve color="#1f77b4" name="/control/command/actuation_cmd/actuation/accel_cmd"/>
+       <curve color="#1ac938" name="minus_brake_cmd"/>
+      </plot>
+     </DockArea>
+     <DockArea name="...">
+      <plot style="Lines" flip_y="false" mode="TimeSeries" flip_x="false">
+       <range right="9.678637" bottom="-0.000027" top="0.000026" left="0.000000"/>
+       <limitY/>
+       <curve color="#1f77b4" name="/vehicle/status/steering_status/steering_tire_angle"/>
+       <curve color="#ff7f0e" name="/control/command/control_cmd/lateral/steering_tire_angle"/>
+       <curve color="#9467bd" name="/awsim/control_cmd/lateral/steering_tire_angle"/>
+      </plot>
+     </DockArea>
+    </DockSplitter>
+   </Container>
+  </Tab>
+  <currentTabIndex index="0"/>
+ </tabbed_widget>
+ <use_relative_time_offset enabled="1"/>
+ <!-- - - - - - - - - - - - - - - -->
+ <!-- - - - - - - - - - - - - - - -->
+ <Plugins>
+  <plugin ID="DataLoad CSV">
+   <parameters delimiter="0" time_axis=""/>
+  </plugin>
+  <plugin ID="DataLoad MCAP"/>
+  <plugin ID="DataLoad ROS2 bags">
+   <use_header_stamp value="false"/>
+   <discard_large_arrays value="true"/>
+   <max_array_size value="100"/>
+   <boolean_strings_to_number value="true"/>
+   <remove_suffix_from_strings value="true"/>
+   <selected_topics value="/control/command/actuation_cmd;/control/command/control_cmd;/localization/acceleration;/localization/gyro_twist;/localization/gyro_twist_raw;/localization/pose;/localization/pose_with_covariance;/localization/twist;/sensing/gnss/gnss_fixed;/sensing/gnss/nav_sat_fix;/sensing/gnss/pose;/sensing/gnss/pose_with_covariance;/sensing/imu/imu_data;/sensing/imu/imu_raw;/sensing/vehicle_velocity_converter/twist_with_covariance;/vehicle/raw_vehicle_cmd_converter/debug/steer_pid;/vehicle/status/actuation_status;/vehicle/status/control_mode;/vehicle/status/gear_status;/vehicle/status/steering_status;/vehicle/status/velocity_status"/>
+  </plugin>
+  <plugin ID="DataLoad ULog"/>
+  <plugin ID="ROS2 Topic Subscriber">
+   <use_header_stamp value="false"/>
+   <discard_large_arrays value="true"/>
+   <max_array_size value="100"/>
+   <boolean_strings_to_number value="true"/>
+   <remove_suffix_from_strings value="true"/>
+   <selected_topics value="/awsim/control_cmd;/control/command/actuation_cmd;/control/command/control_cmd;/localization/acceleration;/localization/kinematic_state;/sensing/gnss/pose_with_covariance;/sensing/imu/imu_raw;/tf;/vehicle/status/gear_status;/vehicle/status/steering_status;/vehicle/status/velocity_status;/vehicle/status/control_mode"/>
+  </plugin>
+  <plugin ID="UDP Server"/>
+  <plugin ID="WebSocket Server"/>
+  <plugin ID="ZMQ Subscriber"/>
+  <plugin ID="Fast Fourier Transform"/>
+  <plugin ID="Quaternion to RPY"/>
+  <plugin ID="Reactive Script Editor">
+   <library code="--[[ Helper function to create a series from arrays&#xa;&#xa; new_series: a series previously created with ScatterXY.new(name)&#xa; prefix:     prefix of the timeseries, before the index of the array&#xa; suffix_X:   suffix to complete the name of the series containing the X value. If [nil], use the index of the array.&#xa; suffix_Y:   suffix to complete the name of the series containing the Y value&#xa; timestamp:   usually the tracker_time variable&#xa;              &#xa; Example:&#xa; &#xa; Assuming we have multiple series in the form:&#xa; &#xa;   /trajectory/node.{X}/position/x&#xa;   /trajectory/node.{X}/position/y&#xa;   &#xa; where {N} is the index of the array (integer). We can create a reactive series from the array with:&#xa; &#xa;   new_series = ScatterXY.new(&quot;my_trajectory&quot;) &#xa;   CreateSeriesFromArray( new_series, &quot;/trajectory/node&quot;, &quot;position/x&quot;, &quot;position/y&quot;, tracker_time );&#xa;--]]&#xa;&#xa;function CreateSeriesFromArray( new_series, prefix, suffix_X, suffix_Y, timestamp )&#xa;  &#xa;  --- clear previous values&#xa;  new_series:clear()&#xa;  &#xa;  --- Append points to new_series&#xa;  index = 0&#xa;  while(true) do&#xa;&#xa;    x = index;&#xa;    -- if not nil, get the X coordinate from a series&#xa;    if suffix_X ~= nil then &#xa;      series_x = TimeseriesView.find( string.format( &quot;%s.%d/%s&quot;, prefix, index, suffix_X) )&#xa;      if series_x == nil then break end&#xa;      x = series_x:atTime(timestamp)&#x9; &#xa;    end&#xa;    &#xa;    series_y = TimeseriesView.find( string.format( &quot;%s.%d/%s&quot;, prefix, index, suffix_Y) )&#xa;    if series_y == nil then break end &#xa;    y = series_y:atTime(timestamp)&#xa;    &#xa;    new_series:push_back(x,y)&#xa;    index = index+1&#xa;  end&#xa;end&#xa;&#xa;--[[ Similar to the built-in function GetSeriesNames(), but select only the names with a give prefix. --]]&#xa;&#xa;function GetSeriesNamesByPrefix(prefix)&#xa;  -- GetSeriesNames(9 is a built-in function&#xa;  all_names = GetSeriesNames()&#xa;  filtered_names = {}&#xa;  for i, name in ipairs(all_names)  do&#xa;    -- check the prefix&#xa;    if name:find(prefix, 1, #prefix) then&#xa;      table.insert(filtered_names, name);&#xa;    end&#xa;  end&#xa;  return filtered_names&#xa;end&#xa;&#xa;--[[ Modify an existing series, applying offsets to all their X and Y values&#xa;&#xa; series: an existing timeseries, obtained with TimeseriesView.find(name)&#xa; delta_x: offset to apply to each x value&#xa; delta_y: offset to apply to each y value &#xa;  &#xa;--]]&#xa;&#xa;function ApplyOffsetInPlace(series, delta_x, delta_y)&#xa;  -- use C++ indeces, not Lua indeces&#xa;  for index=0, series:size()-1 do&#xa;    x,y = series:at(index)&#xa;    series:set(index, x + delta_x, y + delta_y)&#xa;  end&#xa;end&#xa;"/>
+   <scripts/>
+  </plugin>
+  <plugin ID="CSV Exporter"/>
+  <plugin ID="ROS2 Topic Re-Publisher"/>
+ </Plugins>
+ <!-- - - - - - - - - - - - - - - -->
+ <previouslyLoaded_Datafiles/>
+ <previouslyLoaded_Streamer name="ROS2 Topic Subscriber"/>
+ <!-- - - - - - - - - - - - - - - -->
+ <customMathEquations>
+  <snippet name="minus_brake_cmd">
+   <global></global>
+   <function>return -value</function>
+   <linked_source>/control/command/actuation_cmd/actuation/brake_cmd</linked_source>
+  </snippet>
+ </customMathEquations>
+ <snippets/>
+ <!-- - - - - - - - - - - - - - - -->
+</root>
+

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_awsim_adapter/launch/aichallenge_awsim_adapter.launch.xml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_awsim_adapter/launch/aichallenge_awsim_adapter.launch.xml
@@ -4,7 +4,12 @@
   <arg name="csv_path_brake_map" default="$(find-pkg-share aichallenge_submit_launch)/data/brake_map.csv"/>
 
   <node pkg="aichallenge_awsim_adapter" exec="actuation_cmd_converter">
+    <param name="accel_delay_sec" value="0.1"/>
     <param name="steer_delay_sec" value="0.2"/>
+    <param name="accel_limit" value="0.7"/>       <!-- m/s^2 -->
+    <param name="brake_limit" value="-5.0"/>      <!-- m/s^2 -->
+    <param name="steer_limit" value="0.5585"/>    <!-- rad -->
+    <param name="steer_rate_limit" value="0.35"/> <!-- rad/s -->
     <param name="csv_path_accel_map" value="$(var csv_path_accel_map)"/>
     <param name="csv_path_brake_map" value="$(var csv_path_brake_map)"/>
   </node>

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_awsim_adapter/src/actuation_cmd_converter.hpp
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_awsim_adapter/src/actuation_cmd_converter.hpp
@@ -25,11 +25,13 @@
 #include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
 #include <autoware_auto_vehicle_msgs/msg/gear_report.hpp>
 #include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
+#include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
 #include <tier4_vehicle_msgs/msg/actuation_command_stamped.hpp>
 
 using autoware_auto_control_msgs::msg::AckermannControlCommand;
 using autoware_auto_vehicle_msgs::msg::GearReport;
 using autoware_auto_vehicle_msgs::msg::VelocityReport;
+using autoware_auto_vehicle_msgs::msg::SteeringReport;
 using tier4_vehicle_msgs::msg::ActuationCommandStamped;
 
 class ActuationCmdConverter : public rclcpp::Node
@@ -41,24 +43,34 @@ private:
   rclcpp::Subscription<ActuationCommandStamped>::SharedPtr sub_actuation_;
   rclcpp::Subscription<GearReport>::SharedPtr sub_gear_;
   rclcpp::Subscription<VelocityReport>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<SteeringReport>::SharedPtr sub_steering_;
   rclcpp::Publisher<AckermannControlCommand>::SharedPtr pub_ackermann_;
 
   void on_actuation_cmd(const ActuationCommandStamped::ConstSharedPtr msg);
   void on_gear_report(const GearReport::ConstSharedPtr msg);
   void on_velocity_report(const VelocityReport::ConstSharedPtr msg);
+  void on_steering_report(const SteeringReport::ConstSharedPtr msg);
 
   double get_acceleration(const ActuationCommandStamped & cmd, const double velocity);
   raw_vehicle_cmd_converter::AccelMap accel_map_;
   raw_vehicle_cmd_converter::BrakeMap brake_map_;
   GearReport::ConstSharedPtr gear_report_;
   VelocityReport::ConstSharedPtr velocity_report_;
+  SteeringReport::ConstSharedPtr steering_report_;
 
-  std::deque<std::pair<rclcpp::Time, double>> steer_cmd_history_;
+  std::deque<std::pair<rclcpp::Time, double>> accel_cmd_history_, steer_cmd_history_;
+  std::optional<AckermannControlCommand> last_ackermann_cmd_;
+
   // delay for steering command
-  std::chrono::duration<double> delay_; 
-  double get_delayed_steer_cmd(const rclcpp::Time& current_time);
-  double steer_delay_sec_;
- 
+  std::chrono::duration<double> accel_delay_, steer_delay_; 
+  double get_delayed_cmd(
+    std::deque<std::pair<rclcpp::Time, double>>& cmd_history,
+    const rclcpp::Time& current_time,
+    const std::chrono::duration<double>& delay);
+  double accel_delay_sec_, steer_delay_sec_;
+
+  // limits
+  double accel_limit_, brake_limit_, steer_limit_, steer_rate_limit_;
 };
 
 #endif  // AUTOWARE_EXTERNAL_CMD_CONVERTER__NODE_HPP_


### PR DESCRIPTION
AWSIMでの挙動を実機に近づけるために、awsim用のactuation_cmd_converterに、steer_delayとは別に accel delay を乗せる機能と、accel/brake/steer_rate で limit する機能を追加しました。
一旦パラメータはlaunchでそれっぽい値を以下のように与えています。

```
    <param name="accel_delay_sec" value="0.1"/>
    <param name="steer_delay_sec" value="0.2"/>
    <param name="accel_limit" value="0.7"/>       <!-- m/s^2 -->
    <param name="brake_limit" value="-5.0"/>      <!-- m/s^2 -->
    <param name="steer_limit" value="0.5585"/>    <!-- rad -->
    <param name="steer_rate_limit" value="0.35"/> <!-- rad/s -->
```

まだあまり評価はできていないですが、それっぽく動作することはplotjugglerで確認しています。

![Screenshot from 2024-10-19 14-34-49](https://github.com/user-attachments/assets/8b14701c-b900-4bcf-a6de-45e6a47c3b97)
![Screenshot from 2024-10-19 14-20-25](https://github.com/user-attachments/assets/222f14c4-39d3-4e9c-b206-0260c47779a4)
