### PR TITLE
sensor_converter: gnss の途絶を模擬

### DIFF
--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_awsim_adapter/config/sensor_converter.param.yaml
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_awsim_adapter/config/sensor_converter.param.yaml
@@ -28,6 +28,10 @@
     # gnss_pose_cov_stddev: 0.015
     gnss_pose_cov_stddev: 0.0015
 
+    gnss_lost_probability: 0.005
+    gnss_lost_time_mean: 2.0
+    gnss_lost_time_stddev: 0.3
+
     imu_acc_mean: 0.0
     imu_acc_stddev: 0.001
     imu_ang_mean: 0.0

--- a/aichallenge/workspace/src/aichallenge_system/aichallenge_awsim_adapter/src/sensor_converter.hpp
+++ b/aichallenge/workspace/src/aichallenge_system/aichallenge_awsim_adapter/src/sensor_converter.hpp
@@ -37,7 +37,7 @@ public:
 
     MultimodalDistribution(const std::vector<double>& means, const std::vector<double>& stddevs, const std::vector<double>& weights)
         : mix_dist_(0.0, 1.0), cumulative_weights_(weights.size()) {
-        
+
         // Ensure the means, stddevs, and weights vectors are the same size
         if (means.size() != stddevs.size() || means.size() != weights.size()) {
             throw std::invalid_argument("Vectors of means, stddevs, and weights must be the same size.");
@@ -122,6 +122,12 @@ private:
   std::normal_distribution<double> imu_ang_distribution_;
   std::normal_distribution<double> imu_ori_distribution_;
   std::normal_distribution<double> steering_angle_distribution_;
+
+  double gnss_lost_probability_;
+  std::bernoulli_distribution gnss_lost_dist_;
+  double gnss_lost_time_mean_;
+  double gnss_lost_time_stddev_;
+  std::normal_distribution<double> gnss_lost_time_dist_;
 
   double gnss_pose_cov_publish_period_;
   double gnss_pose_cov_publish_period_mean_;


### PR DESCRIPTION
GNSS の途絶を模擬するようにしました。少なくとも kart_diag が途絶を検知できるかテストするために欲しく、実装しました。

一定の確率で途絶が発生し、途絶時間はガウス分布から生成します。

パラメータの説明
- gnss_lost_probability: 通信途絶の発生確率
  -  0.0 とすれば途絶が発生しません
- gnss_lost_time_mean, stddev: 途絶時間の平均と標準偏差

現状の発生確率や途絶時間の値は適当です。
佐藤さんの方でいろんな背景があって現状があると思うので、マージしなくてもいいし、マージしても機能を無効化してもいいです。


なお、走行テストした感じ 3 秒くらい途絶してもあまり影響なかったです。オドメトリが実際よりきれいすぎるからかもです。